### PR TITLE
CI fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Deploy Test Reports to Website
         uses: peaceiris/actions-gh-pages@v3
         with:
+          enable_jekyll: true
           deploy_key: ${{ secrets.SITE_DEPLOY_KEY }}
           external_repository: engteam14/website2
           publish_branch: main
@@ -72,6 +73,7 @@ jobs:
       - name: Deploy Jar
         uses: peaceiris/actions-gh-pages@v3
         with:
+          enable_jekyll: true
           deploy_key: ${{ secrets.SITE_DEPLOY_KEY }}
           external_repository: engteam14/website2
           publish_branch: main
@@ -106,6 +108,7 @@ jobs:
       - name: Deploy Documentation to Website
         uses: peaceiris/actions-gh-pages@v3
         with:
+          enable_jekyll: true
           deploy_key: ${{ secrets.SITE_DEPLOY_KEY }}
           external_repository: engteam14/website2
           publish_branch: main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Deploy Test Reports to Website
         uses: peaceiris/actions-gh-pages@v3
         with:
+          enable_jekyll: true
           deploy_key: ${{ secrets.SITE_DEPLOY_KEY }}
           external_repository: engteam14/website2
           publish_branch: main

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,6 +6,9 @@ dependencies {
     implementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
     implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
     implementation 'junit:junit:4.13.1'
+
+    testImplementation "org.junit.vintage:junit-vintage-engine:5.8.1"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.8.1"
 }
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 


### PR DESCRIPTION
- Test reports generated by GitHub actions generate for junit4 as well as junit 5 now
- Now prevents deploy to website from causing a nojekyll file to be generated, which breaks the website

Reviewing responsibility: @katie291100 @Cdsspnks96 